### PR TITLE
Fix toggle function on splitter

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -37,7 +37,7 @@ export default {
       },
       mutations: {
         toggle(state, shouldOpen) {
-          if (shouldOpen instanceof Boolean) {
+          if (typeof shouldOpen == 'boolean') {
             state.open = shouldOpen;
           } else {
             state.open = !state.open;


### PR DESCRIPTION
When I try use `store.commit('splitter/toggle', false)` the instanceof `shouldOpen` not is `Boolean`.
Check more info on https://stackoverflow.com/a/6625960/511514